### PR TITLE
Improve stop hook

### DIFF
--- a/charms/openfga-k8s/src/charm.py
+++ b/charms/openfga-k8s/src/charm.py
@@ -177,7 +177,8 @@ class OpenFGAOperatorCharm(CharmBase):
                 logger.warning("service not found, won't stop")
                 return
             if service.is_running():
-                container.stop("openfga")
+                container.stop(SERVICE_NAME)
+        self.unit.status = WaitingStatus("service stopped")
 
     def _on_update_status(self, _):
         """Update the status of the charm."""

--- a/charms/openfga-k8s/src/charm.py
+++ b/charms/openfga-k8s/src/charm.py
@@ -42,7 +42,7 @@ from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase, RelationChangedEvent, RelationJoinedEvent
 from ops.jujuversion import JujuVersion
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus, ModelError
+from ops.model import ActiveStatus, BlockedStatus, ModelError, Relation, WaitingStatus
 from ops.pebble import ExecError
 from requests.models import Response
 

--- a/charms/openfga-k8s/src/charm.py
+++ b/charms/openfga-k8s/src/charm.py
@@ -42,7 +42,7 @@ from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase, RelationChangedEvent, RelationJoinedEvent
 from ops.jujuversion import JujuVersion
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus, ModelError
 from ops.pebble import ExecError
 from requests.models import Response
 
@@ -66,6 +66,8 @@ LOG_FILE = "/var/log/openfga-k8s"
 LOGROTATE_CONFIG_PATH = "/etc/logrotate.d/openfga"
 
 OPENFGA_SERVER_PORT = 8080
+
+SERVICE_NAME = "openfga"
 
 
 class OpenFGAOperatorCharm(CharmBase):
@@ -169,8 +171,13 @@ class OpenFGAOperatorCharm(CharmBase):
         """Stop OpenFGA."""
         container = self.unit.get_container(WORKLOAD_CONTAINER)
         if container.can_connect():
-            container.stop("openfga")
-        self._ready()
+            try:
+                service = container.get_service(SERVICE_NAME)
+            except ModelError:
+                logger.warning("service not found, won't stop")
+                return
+            if service.is_running():
+                container.stop("openfga")
 
     def _on_update_status(self, _):
         """Update the status of the charm."""
@@ -295,7 +302,7 @@ class OpenFGAOperatorCharm(CharmBase):
             "summary": "openfga layer",
             "description": "pebble layer for openfga",
             "services": {
-                "openfga": {
+                SERVICE_NAME: {
                     "override": "merge",
                     "summary": "OpenFGA",
                     "command": "sh -c '/app/openfga run | tee {LOG_FILE}'",
@@ -313,10 +320,10 @@ class OpenFGAOperatorCharm(CharmBase):
         }
         container.add_layer("openfga", pebble_layer, combine=True)
         if self._ready():
-            if container.get_service("openfga").is_running():
+            if container.get_service(SERVICE_NAME).is_running():
                 container.replan()
             else:
-                container.start("openfga")
+                container.start(SERVICE_NAME)
             self.unit.status = ActiveStatus()
             if self.unit.is_leader():
                 self.app.status = ActiveStatus()
@@ -368,11 +375,11 @@ class OpenFGAOperatorCharm(CharmBase):
 
         if container.can_connect():
             plan = container.get_plan()
-            if plan.services.get("openfga") is None:
+            if plan.services.get(SERVICE_NAME) is None:
                 self.unit.status = WaitingStatus("waiting for service")
                 return False
 
-            env_vars = plan.services.get("openfga").environment
+            env_vars = plan.services.get(SERVICE_NAME).environment
 
             for setting in REQUIRED_SETTINGS:
                 if not env_vars.get(setting, ""):
@@ -381,7 +388,7 @@ class OpenFGAOperatorCharm(CharmBase):
                     )
                     return False
 
-            if container.get_service("openfga").is_running():
+            if container.get_service(SERVICE_NAME).is_running():
                 self.unit.status = ActiveStatus()
 
             return True

--- a/charms/openfga-k8s/tests/unit/test_charm.py
+++ b/charms/openfga-k8s/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ import os
 import pathlib
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from ops.testing import Harness
 
@@ -34,8 +34,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.container_pebble_ready("openfga")
 
-    @patch("charm.OpenFGAOperatorCharm._get_logrotate_config")
-    def test_logrotate_config_pushed(self, get_logrotate_config: MagicMock):
+    def test_logrotate_config_pushed(self):
         self.harness.set_leader(True)
 
         rel_id = self.harness.add_relation("peer", "openfga")
@@ -51,7 +50,9 @@ class TestCharm(unittest.TestCase):
 
         container = self.harness.model.unit.get_container("openfga")
         self.harness.charm.on.openfga_pebble_ready.emit(container)
-        get_logrotate_config.assert_called()
+        root = self.harness.get_filesystem_root("openfga")
+        config = (root / "etc/logrotate.d/openfga").read_text()
+        self.assertIn("/var/log/openfga-k8s {", config)
 
     @patch("secrets.token_urlsafe")
     def test_on_config_changed(self, token_urlsafe):


### PR DESCRIPTION
## Description

The stop hook was found to error out when the underlying Juju controller managing the application was upgrading. The stop hook was called but the service was not found causing the crash. This checks for the service before stopping the application.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests