### PR TITLE
Handle ModelError that is raised when service does not exist

### DIFF
--- a/charms/openfga-k8s/src/charm.py
+++ b/charms/openfga-k8s/src/charm.py
@@ -406,6 +406,7 @@ class OpenFGAOperatorCharm(CharmBase):
         try:
             svc = container.get_service(SERVICE_NAME)
         except ModelError:
+            logger.error(f"{SERVICE_NAME} is not running")
             return False
         if not svc.is_running():
             logger.error(f"{SERVICE_NAME} is not running")

--- a/charms/openfga-k8s/src/charm.py
+++ b/charms/openfga-k8s/src/charm.py
@@ -403,7 +403,11 @@ class OpenFGAOperatorCharm(CharmBase):
         if not container.can_connect():
             logger.error(f"Cannot connect to container {WORKLOAD_CONTAINER}")
             return False
-        if not container.get_service(SERVICE_NAME).is_running():
+        try:
+            svc = container.get_service(SERVICE_NAME)
+        except ModelError:
+            return False
+        if not svc.is_running():
             logger.error(f"{SERVICE_NAME} is not running")
             return False
         return True


### PR DESCRIPTION
## Description

As the title implies, ensure we check for `ModelError` when calling `container.get_service(SERVICE_NAME)`